### PR TITLE
Google sheet error handling

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version}}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from click.testing import CliRunner
 import pytest
@@ -40,6 +41,17 @@ def test_vendor_file_cli_get_all_vendor_files_no_creds(mocker, cli_runner, caplo
         40,
         "Vendor credentials file not found.",
     ) in caplog.record_tuples
+
+
+def test_vendor_file_cli_get_all_vendor_files_test(cli_runner, caplog):
+    logger = logging.getLogger("vendor_file_cli")
+    loggly = logging.NullHandler()
+    loggly.name = "loggly"
+    logger.addHandler(loggly)
+    result = cli_runner.invoke(cli=vendor_file_cli, args=["all-vendor-files", "--test"])
+    assert result.exit_code == 0
+    assert "Running in test mode" in caplog.text
+    assert logger.handlers == []
 
 
 def test_vendor_file_cli_get_available_vendors(cli_runner):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -17,6 +17,7 @@ def test_get_single_file_no_validation(stub_client, stub_file_info, vendor, capl
         file=stub_file_info,
         vendor_client=vendor_client,
         nsdrop_client=nsdrop_client,
+        test=True,
     )
     assert (
         f"({vendor.upper()}) Connecting to ftp.{vendor}.com via FTP client"
@@ -37,6 +38,7 @@ def test_get_single_file_with_validation(stub_client, stub_file_info, caplog):
         file=stub_file_info,
         vendor_client=vendor_client,
         nsdrop_client=nsdrop_client,
+        test=True,
     )
     assert "(EASTVIEW) Connecting to ftp.eastview.com via SFTP client" in caplog.text
     assert "(NSDROP) Connecting to ftp.nsdrop.com via SFTP client" in caplog.text
@@ -53,6 +55,7 @@ def test_get_single_file_bakertaylor_bpl_root(stub_client, stub_file_info, caplo
         file=stub_file_info,
         vendor_client=vendor_client,
         nsdrop_client=nsdrop_client,
+        test=True,
     )
     assert (
         "(BAKERTAYLOR_BPL) Connecting to ftp.bakertaylor_bpl.com via FTP client"

--- a/vendor_file_cli/__init__.py
+++ b/vendor_file_cli/__init__.py
@@ -25,7 +25,8 @@ def vendor_file_cli() -> None:
     "all-vendor-files",
     short_help="Retrieve and validate files that are not in NSDROP.",
 )
-def get_all_vendor_files() -> None:
+@click.option("--test", is_flag=True, help="Run in test mode.")
+def get_all_vendor_files(test) -> None:
     """
     Retrieve files from vendor server which were created in last year and are not
     present in vendor's NSDROP directory. Creates list of files on vendor server
@@ -34,15 +35,26 @@ def get_all_vendor_files() -> None:
     and Amalivre (SASB) before copying them to NSDROP and writes output of validation
     to google sheet. Files are copied to NSDROP/vendor_records/{vendor_name}.
 
+    If test flag is passed, the loggly handler is removed so log messages are only
+    written to the console and log file. The output of any validation is written
+    to a test sheet.
+
     Args:
-        None
+        test: flag to run in test mode
 
     Returns:
         None
 
     """
+    if test:
+        handlers = logger.handlers
+        for handler in handlers:
+            if handler.name == "loggly":
+                logger.removeHandler(handler)
+        logger.info("Running in test mode.")
+
     vendor_list = get_vendor_list()
-    get_vendor_files(vendors=vendor_list, days=365)
+    get_vendor_files(vendors=vendor_list, days=365, test=test)
 
 
 @vendor_file_cli.command("available-vendors", short_help="List all configured vendors.")

--- a/vendor_file_cli/commands.py
+++ b/vendor_file_cli/commands.py
@@ -20,6 +20,7 @@ def get_vendor_files(
     vendors: list[str],
     days: int = 0,
     hours: int = 0,
+    test: bool = False,
 ) -> None:
     """
     Retrieve files from remote server for vendors in `vendor_list`. Forms timedelta
@@ -60,6 +61,7 @@ def get_vendor_files(
                             file=file,
                             vendor_client=vendor_client,
                             nsdrop_client=nsdrop_client,
+                            test=test,
                         )
                     if len(files) > 0:
                         logger.info(

--- a/vendor_file_cli/validator.py
+++ b/vendor_file_cli/validator.py
@@ -19,7 +19,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_single_file(
-    vendor: str, file: FileInfo, vendor_client: Client, nsdrop_client: Client
+    vendor: str,
+    file: FileInfo,
+    vendor_client: Client,
+    nsdrop_client: Client,
+    test: bool,
 ) -> File:
     """
     Get a file from a vendor server and copy it to the vendor's NSDROP directory.
@@ -43,13 +47,13 @@ def get_single_file(
         remote_dir = os.environ[f"{vendor.upper()}_SRC"]
     nsdrop_dir = os.environ[f"{vendor.upper()}_DST"]
     fetched_file = vendor_client.get_file(file=file, remote_dir=remote_dir)
+    nsdrop_client.put_file(file=fetched_file, dir=nsdrop_dir, remote=True, check=True)
     if vendor.upper() in ["EASTVIEW", "LEILA", "AMALIVRE_SASB"]:
         logger.debug(
             f"({nsdrop_client.name}) Validating {vendor} file: {fetched_file.file_name}"
         )
         output = validate_file(file_obj=fetched_file, vendor=vendor)
-        write_data_to_sheet(output)
-    nsdrop_client.put_file(file=fetched_file, dir=nsdrop_dir, remote=True, check=True)
+        write_data_to_sheet(output, test=test)
     return fetched_file
 
 


### PR DESCRIPTION
Changed
 - simplified `cli_runner` fixture
 - added additional fixture to test authorization errors with google sheet
 - renamed fixtures for clarity
 - reordered validation and copy for .mrc files in `get_single_file` function. files are now copied to NSDROP before validation in case errors are raised during google sheet config or writting
 - credential load workflow for google sheet API. creds are now read from env vars rather than from a file
 - 

Added
 - `--test` flag for `all-vendor-files` command so that the command can be tested and data will not be written to live google sheet or loggly logs
 - additional tests for `--test` flag on `all-vendor-files` command
 - error handling for `write_data_to_sheet` so that commands do not fail if validation data cannot be written to google sheet
 - added test spreadsheet to `write_data_to_sheet` so that data isn't written to live sheet during testing