### PR TITLE
fixed error with mixed validation files

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,3 +107,20 @@ def test_vendor_file_cli_validate_vendor_files_invalid_vendor(cli_runner, caplog
         "Vendor not supported for validation."
         "Only EASTVIEW, LEILA, and AMALIVRE_SASB supported." in result.stdout
     )
+
+
+def test_vendor_file_cli_validate_vendor_files_test(cli_runner, caplog):
+    logger = logging.getLogger("vendor_file_cli")
+    loggly = logging.NullHandler()
+    loggly.name = "loggly"
+    logger.addHandler(loggly)
+    result = cli_runner.invoke(
+        cli=vendor_file_cli,
+        args=["validate-file", "-v", "eastview", "-f", "foo.mrc", "--test"],
+    )
+    assert result.exit_code == 0
+    assert "(NSDROP) Connecting to " in caplog.text
+    assert "(NSDROP) Validating eastview file: foo.mrc" in caplog.text
+    assert result.exit_code == 0
+    assert "Running in test mode" in caplog.text
+    assert logger.handlers == []

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -36,12 +36,12 @@ def test_get_vendor_files_no_files(stub_client, caplog):
 
 
 def test_validate_files(stub_client, caplog):
-    validate_files(vendor="eastview", files=None)
+    validate_files(vendor="eastview", files=None, test=True)
     assert "(NSDROP) Connecting to " in caplog.text
     assert "(NSDROP) Validating eastview file: bar.mrc" in caplog.text
 
 
 def test_validate_files_with_list(stub_client, caplog):
-    validate_files(vendor="eastview", files=["foo.mrc"])
+    validate_files(vendor="eastview", files=["foo.mrc"], test=True)
     assert "(NSDROP) Connecting to " in caplog.text
     assert "(NSDROP) Validating eastview file: foo.mrc" in caplog.text

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -100,8 +100,8 @@ def test_get_vendor_file_list(stub_client, vendor, caplog):
         ("midwest_nypl", "MIDWEST_NYPL"),
     ],
 )
-def test_validate_file(stub_file, vendor, vendor_code):
-    out_dict = validate_file(stub_file, vendor)
+def test_validate_file(stub_file, vendor, vendor_code, mock_sheet_config):
+    out_dict = validate_file(stub_file, vendor, test=True)
     assert sorted([i for i in out_dict.keys()]) == sorted(
         [
             "valid",
@@ -110,13 +110,31 @@ def test_validate_file(stub_file, vendor, vendor_code):
             "file_name",
             "validation_date",
             "vendor_code",
+            "error_count",
+            "missing_field_count",
+            "missing_fields",
+            "extra_field_count",
+            "extra_fields",
+            "invalid_field_count",
+            "invalid_fields",
+            "order_item_mismatches",
         ]
     )
     assert out_dict["vendor_code"] == [vendor_code]
 
 
 def test_validate_single_record(mock_valid_record):
-    assert validate_single_record(mock_valid_record) == {"valid": True}
+    assert validate_single_record(mock_valid_record) == {
+        "valid": True,
+        "error_count": "",
+        "missing_field_count": "",
+        "missing_fields": "",
+        "extra_field_count": "",
+        "extra_fields": "",
+        "invalid_field_count": "",
+        "invalid_fields": "",
+        "order_item_mismatches": "",
+    }
 
 
 def test_validate_single_record_invalid(mock_invalid_record):

--- a/vendor_file_cli/__init__.py
+++ b/vendor_file_cli/__init__.py
@@ -80,13 +80,8 @@ def get_available_vendors() -> None:
     "file",
     help="The file you would like to validate.",
 )
-@click.option(
-    "--write",
-    is_flag=True,
-    default=False,
-    help="Whether or not to write data to google sheet.",
-)
-def validate_vendor_files(vendor: str, file: str, write: bool) -> None:
+@click.option("--test", is_flag=True, help="Run in test mode.")
+def validate_vendor_files(vendor: str, file: str, test: bool) -> None:
     """
     Validate files for a specific vendor.
 
@@ -105,7 +100,13 @@ def validate_vendor_files(vendor: str, file: str, write: bool) -> None:
             "Only EASTVIEW, LEILA, and AMALIVRE_SASB supported."
         )
         return
-    validate_files(vendor=vendor, files=[file], write=write)
+    if test:
+        handlers = logger.handlers
+        for handler in handlers:
+            if handler.name == "loggly":
+                logger.removeHandler(handler)
+        logger.info("Running in test mode.")
+    validate_files(vendor=vendor, files=[file], test=test)
 
 
 @vendor_file_cli.command(

--- a/vendor_file_cli/__init__.py
+++ b/vendor_file_cli/__init__.py
@@ -80,7 +80,13 @@ def get_available_vendors() -> None:
     "file",
     help="The file you would like to validate.",
 )
-def validate_vendor_files(vendor: str, file: str) -> None:
+@click.option(
+    "--write",
+    is_flag=True,
+    default=False,
+    help="Whether or not to write data to google sheet.",
+)
+def validate_vendor_files(vendor: str, file: str, write: bool) -> None:
     """
     Validate files for a specific vendor.
 
@@ -99,7 +105,7 @@ def validate_vendor_files(vendor: str, file: str) -> None:
             "Only EASTVIEW, LEILA, and AMALIVRE_SASB supported."
         )
         return
-    validate_files(vendor=vendor, files=[file])
+    validate_files(vendor=vendor, files=[file], write=write)
 
 
 @vendor_file_cli.command(

--- a/vendor_file_cli/commands.py
+++ b/vendor_file_cli/commands.py
@@ -72,7 +72,7 @@ def get_vendor_files(
             continue
 
 
-def validate_files(vendor: str, files: list | None) -> None:
+def validate_files(vendor: str, files: list | None, write: bool) -> None:
     """
     Validate files on NSDROP for a specific vendor.
 
@@ -100,5 +100,5 @@ def validate_files(vendor: str, files: list | None) -> None:
         client = connect("nsdrop")
         file_obj = client.get_file(file=file, remote_dir=file_dir)
         logger.debug(f"({client.name}) Validating {vendor} file: {file_obj.file_name}")
-        validate_file(file_obj=file_obj, vendor=vendor)
+        validate_file(file_obj=file_obj, vendor=vendor, write=write)
         client.close()

--- a/vendor_file_cli/commands.py
+++ b/vendor_file_cli/commands.py
@@ -72,7 +72,7 @@ def get_vendor_files(
             continue
 
 
-def validate_files(vendor: str, files: list | None, write: bool) -> None:
+def validate_files(vendor: str, files: list | None, test: bool) -> None:
     """
     Validate files on NSDROP for a specific vendor.
 
@@ -100,5 +100,5 @@ def validate_files(vendor: str, files: list | None, write: bool) -> None:
         client = connect("nsdrop")
         file_obj = client.get_file(file=file, remote_dir=file_dir)
         logger.debug(f"({client.name}) Validating {vendor} file: {file_obj.file_name}")
-        validate_file(file_obj=file_obj, vendor=vendor, write=write)
+        validate_file(file_obj=file_obj, vendor=vendor, test=test)
         client.close()

--- a/vendor_file_cli/utils.py
+++ b/vendor_file_cli/utils.py
@@ -222,7 +222,7 @@ def read_marc_file_stream(file_obj: File) -> Generator[Record, None, None]:
         yield record
 
 
-def write_data_to_sheet(values: dict, test: bool) -> Union[dict, None]:
+def write_data_to_sheet(values: dict, write: bool) -> Union[dict, None]:
     """
     Write output of validation to google sheet.
 
@@ -261,10 +261,10 @@ def write_data_to_sheet(values: dict, test: bool) -> Union[dict, None]:
         "values": df.values.tolist(),
     }
 
-    if test is True:
-        spreadsheet_id = "1hGzVYaqxXXBSJa3GY52UFKteZgLoWBo6X0sGsTVTpFU"
-    else:
+    if write is True:
         spreadsheet_id = "1ZYuhMIE1WiduV98Pdzzw7RwZ08O-sJo7HJihWVgSOhQ"
+    else:
+        spreadsheet_id = "1hGzVYaqxXXBSJa3GY52UFKteZgLoWBo6X0sGsTVTpFU"
 
     try:
         creds = configure_sheet()

--- a/vendor_file_cli/utils.py
+++ b/vendor_file_cli/utils.py
@@ -222,7 +222,7 @@ def read_marc_file_stream(file_obj: File) -> Generator[Record, None, None]:
         yield record
 
 
-def write_data_to_sheet(values: dict, write: bool) -> Union[dict, None]:
+def write_data_to_sheet(values: dict, test: bool) -> Union[dict, None]:
     """
     Write output of validation to google sheet.
 
@@ -261,10 +261,10 @@ def write_data_to_sheet(values: dict, write: bool) -> Union[dict, None]:
         "values": df.values.tolist(),
     }
 
-    if write is True:
-        spreadsheet_id = "1ZYuhMIE1WiduV98Pdzzw7RwZ08O-sJo7HJihWVgSOhQ"
-    else:
+    if test is True:
         spreadsheet_id = "1hGzVYaqxXXBSJa3GY52UFKteZgLoWBo6X0sGsTVTpFU"
+    else:
+        spreadsheet_id = "1ZYuhMIE1WiduV98Pdzzw7RwZ08O-sJo7HJihWVgSOhQ"
 
     try:
         creds = configure_sheet()

--- a/vendor_file_cli/validator.py
+++ b/vendor_file_cli/validator.py
@@ -52,8 +52,7 @@ def get_single_file(
         logger.debug(
             f"({nsdrop_client.name}) Validating {vendor} file: {fetched_file.file_name}"
         )
-        output = validate_file(file_obj=fetched_file, vendor=vendor)
-        write_data_to_sheet(output, test=test)
+        validate_file(file_obj=fetched_file, vendor=vendor, write=test)
     return fetched_file
 
 
@@ -138,7 +137,7 @@ def get_vendor_file_list(
     return files_to_get
 
 
-def validate_file(file_obj: File, vendor: str) -> dict:
+def validate_file(file_obj: File, vendor: str, write: bool) -> None:
     """
     Validate a file of MARC records and output to google sheet.
 
@@ -179,7 +178,7 @@ def validate_file(file_obj: File, vendor: str) -> dict:
         for k, v in validation_data.items():
             out_dict[k].append(str(v))
         record_n += 1
-    return out_dict
+    write_data_to_sheet(out_dict, write=write)
 
 
 def validate_single_record(record: Record) -> dict[str, Any]:
@@ -209,4 +208,19 @@ def validate_single_record(record: Record) -> dict[str, Any]:
                 "extra_field_count": len(marc_errors.extra_fields),
             }
         )
+    for field in [
+        i
+        for i in [
+            "error_count",
+            "missing_field_count",
+            "extra_field_count",
+            "invalid_field_count",
+            "missing_fields",
+            "extra_fields",
+            "invalid_fields",
+            "order_item_mismatches",
+        ]
+        if i not in out
+    ]:
+        out[field] = ""
     return out

--- a/vendor_file_cli/validator.py
+++ b/vendor_file_cli/validator.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 import datetime
 import logging
 import os
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 from pydantic import ValidationError
 from pymarc import Record
 from file_retriever.file import File, FileInfo
@@ -137,7 +137,7 @@ def get_vendor_file_list(
     return files_to_get
 
 
-def validate_file(file_obj: File, vendor: str, test: bool) -> Dict[str, List[str]]:
+def validate_file(file_obj: File, vendor: str, test: bool) -> dict:
     """
     Validate a file of MARC records and output to google sheet.
 

--- a/vendor_file_cli/validator.py
+++ b/vendor_file_cli/validator.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 import datetime
 import logging
 import os
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 from pydantic import ValidationError
 from pymarc import Record
 from file_retriever.file import File, FileInfo
@@ -52,7 +52,7 @@ def get_single_file(
         logger.debug(
             f"({nsdrop_client.name}) Validating {vendor} file: {fetched_file.file_name}"
         )
-        validate_file(file_obj=fetched_file, vendor=vendor, write=test)
+        validate_file(file_obj=fetched_file, vendor=vendor, test=test)
     return fetched_file
 
 
@@ -137,7 +137,7 @@ def get_vendor_file_list(
     return files_to_get
 
 
-def validate_file(file_obj: File, vendor: str, write: bool) -> None:
+def validate_file(file_obj: File, vendor: str, test: bool) -> Dict[str, List[str]]:
     """
     Validate a file of MARC records and output to google sheet.
 
@@ -178,7 +178,8 @@ def validate_file(file_obj: File, vendor: str, write: bool) -> None:
         for k, v in validation_data.items():
             out_dict[k].append(str(v))
         record_n += 1
-    write_data_to_sheet(out_dict, write=write)
+    write_data_to_sheet(out_dict, test=test)
+    return out_dict
 
 
 def validate_single_record(record: Record) -> dict[str, Any]:


### PR DESCRIPTION
Fixed
 - error caused by files with mixed validation status. If a vendor file contained some records that were valid and others that were invalid, the validation data would not be written to the google sheet.

Changed
 - added `write` flag for `validate-file` command and related functions

Added tests